### PR TITLE
[setup.py] add fallback version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         # for now don't force to change from %-operator to {}
         args: [--keep-percent-format, --py3-plus, --py36-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: "5.7.0"
+    rev: "5.11.5"
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -53,7 +53,7 @@ class Any:
 
 
 class StringWithUseFlags(str):
-    """ A parsed string with support for use flags. """
+    """A parsed string with support for use flags."""
 
     def __init__(self, string):
         self.exprs = None
@@ -65,7 +65,7 @@ class StringWithUseFlags(str):
 
 
 class String(str):
-    """ A plain (unparsed) string. """
+    """A plain (unparsed) string."""
 
     def parse(self, flags):
         raise RuntimeError(
@@ -379,7 +379,7 @@ class Core:
         return generators
 
     def get_virtuals(self):
-        """ Get a list of "virtual" VLNVs provided by this core. """
+        """Get a list of "virtual" VLNVs provided by this core."""
         return self.virtual
 
     def get_parameters(self, flags={}, ext_parameters={}):

--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -288,7 +288,7 @@ class CoreManager:
             self.db.add(core, library)
 
     def add_library(self, library):
-        """ Register a library """
+        """Register a library"""
         abspath = os.path.abspath(os.path.expanduser(library.location))
         _library = self._lm.get_library(abspath, "location")
         if _library:
@@ -300,7 +300,7 @@ class CoreManager:
         self._lm.add_library(library)
 
     def get_libraries(self):
-        """ Get all registered libraries """
+        """Get all registered libraries"""
         return self._lm.get_libraries()
 
     def get_depends(self, core, flags):
@@ -325,17 +325,17 @@ class CoreManager:
         return deps
 
     def get_cores(self):
-        """ Get a dict with all cores, indexed by the core name """
+        """Get a dict with all cores, indexed by the core name"""
         return {str(x.name): x for x in self.db.find()}
 
     def get_core(self, name):
-        """ Get a core with a given name """
+        """Get a core with a given name"""
         c = self.db.find(name)
         c.name.relation = "=="
         return c
 
     def get_generators(self):
-        """ Get a dict with all registered generators, indexed by name """
+        """Get a dict with all registered generators, indexed by name"""
         generators = {}
         for core in self.db.find():
             if hasattr(core, "get_generators"):

--- a/fusesoc/edalizer.py
+++ b/fusesoc/edalizer.py
@@ -56,7 +56,7 @@ class Edalizer:
 
     @property
     def resolved_cores(self):
-        """ Get a list of all "used" cores after the dependency resolution """
+        """Get a list of all "used" cores after the dependency resolution"""
         try:
             return self.core_manager.get_depends(self.toplevel, self.flags)
         except DependencyError as e:
@@ -70,11 +70,11 @@ class Edalizer:
 
     @property
     def discovered_cores(self):
-        """ Get a list of all cores found by fusesoc """
+        """Get a list of all cores found by fusesoc"""
         return self.core_manager.db.find()
 
     def run(self):
-        """ Run all steps to create a EDAM file """
+        """Run all steps to create a EDAM file"""
 
         # Run the setup task on all cores (fetch and patch them as needed)
         self.setup_cores()
@@ -95,20 +95,20 @@ class Edalizer:
         return self.edam
 
     def _core_flags(self, core):
-        """ Get flags for a specific core """
+        """Get flags for a specific core"""
 
         core_flags = self.flags.copy()
         core_flags["is_toplevel"] = core.name == self.toplevel
         return core_flags
 
     def setup_cores(self):
-        """ Setup cores: fetch resources, patch them, etc. """
+        """Setup cores: fetch resources, patch them, etc."""
         for core in self.cores:
             logger.info("Preparing " + str(core.name))
             core.setup()
 
     def extract_generators(self):
-        """ Get all registered generators from the cores """
+        """Get all registered generators from the cores"""
         generators = {}
         for core in self.cores:
             logger.debug("Searching for generators in " + str(core.name))
@@ -121,7 +121,7 @@ class Edalizer:
         self.generators = generators
 
     def run_generators(self):
-        """ Run all generators """
+        """Run all generators"""
         self._resolved_or_generated_cores = []
         for core in self.cores:
             logger.debug("Running generators in " + str(core.name))

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     use_scm_version={
         "relative_to": __file__,
         "write_to": "fusesoc/version.py",
+        "fallback_version": "ot-0.4",
     },
     author="Olof Kindgren",
     author_email="olof.kindgren@gmail.com",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -15,7 +15,6 @@ cores_root = os.path.join(tests_dir, "cores")
 
 
 def test_coregen_provider():
-
     cache_root = tempfile.mkdtemp("coregen_")
     core = Core(os.path.join(cores_root, "misc", "coregencore.core"), cache_root)
 
@@ -72,7 +71,6 @@ def test_github_provider():
 
 
 def test_logicore_provider():
-
     cache_root = tempfile.mkdtemp("logicore_")
     core = Core(os.path.join(cores_root, "misc", "logicorecore.core"), cache_root)
 


### PR DESCRIPTION
We are trying to lock down the `python-requirements.txt` file in the lowRISC/opentitan repository by adding hashes for all dependencies (including transitive dependencies), to satify OpenTitan partner organization-level requirements. To do so, we would like to generate a python-requirements.txt file with the required hashes using the `pip-compile` command from the `pip-tools` package.

The way the version is detected in the `setup.py` configuration in this package is using the `use_scm_version` feature which attempts to extract the version from VCS (i.e., git) metadata. However, this requires installing the package with `pip install git+https://github.com/lowRISC/fusesoc.git@<tag>`. However, to use the `pip-compile` command to generate secure `python-requirements.txt` file (i.e., one with pinned hashes), requires installing packages directly using the HTTPS URL syntax, i.e., `pip install https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.3.zip`, i.e., bypassing git. Unfortunately, this fails to find the version, since there is no git metadata to parse.

Therefore, I updated the `setup.py` configuration to use a "fallback_version".

This addresses part of https://github.com/lowRISC/opentitan/issues/19401.