### PR TITLE
Make fallback verison PEP440 compliant.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     use_scm_version={
         "relative_to": __file__,
         "write_to": "fusesoc/version.py",
-        "fallback_version": "ot-0.4",
+        "fallback_version": "0.4.dev0",
     },
     author="Olof Kindgren",
     author_email="olof.kindgren@gmail.com",


### PR DESCRIPTION
The requirements for version strings seems to have changed since https://github.com/lowRISC/fusesoc/pull/2 was filed.

This addresses part of https://github.com/lowRISC/opentitan/issues/19401.