### PR TITLE
coremanager: Pick preferred cores for virtual VLNVs

### DIFF
--- a/fusesoc/coremanager.py
+++ b/fusesoc/coremanager.py
@@ -113,6 +113,35 @@ class CoreDB:
     def solve(self, top_core, flags):
         return self._solve(top_core, flags)
 
+    def _get_conflict_map(self):
+        """Return a map of cores to their conflicts
+
+        Only one core that implements a virtual VLNV may be selected in a
+        dependency tree. For each core that implements a virtual VLNV, create a
+        set representing all other cores that implement one of the same virtual
+        VLNVs. In the resulting package definitions, these must get "conflicts"
+        constraints.
+        """
+        conflict_map = {}
+        virtual_map = {}
+        for core_data in self._cores.values():
+            core = core_data["core"]
+            _virtuals = core.get_virtuals()
+            for virtual in _virtuals:
+                for simple in virtual.simpleVLNVs():
+                    virtual_pkg = self._package_name(simple)
+                    # FIXME: The real package should include version info
+                    real_pkg = self._package_name(core.name)
+                    virtual_set = virtual_map.setdefault(virtual_pkg, set())
+                    virtual_set.add(real_pkg)
+        for virtual_pkg, virtual_set in virtual_map.items():
+            for real_pkg in virtual_set:
+                conflict_set = conflict_map.setdefault(real_pkg, set())
+                conflict_set |= virtual_set
+        for real_pkg, conflict_set in conflict_map.items():
+            conflict_set.remove(real_pkg)
+        return conflict_map
+
     def _solve(self, top_core, flags={}, only_matching_vlnv=False):
         def eq_vln(this, that):
             return (
@@ -130,6 +159,8 @@ class CoreDB:
         repo = Repository()
         _flags = flags.copy()
         cores = [x["core"] for x in self._cores.values()]
+        conflict_map = self._get_conflict_map()
+
         for core in cores:
             if only_matching_vlnv:
                 if not any(
@@ -151,6 +182,10 @@ class CoreDB:
             if _virtuals:
                 _s = "; provides ( {} )"
                 package_str += _s.format(self._parse_virtual(_virtuals))
+            conflict_set = conflict_map.get(self._package_name(core.name), set())
+            if len(conflict_set) > 0:
+                _s = "; conflicts ( {} )"
+                package_str += _s.format(", ".join(list(conflict_set)))
 
             # Add dependencies only if we want to build the whole dependency
             # tree.

--- a/tests/capi2_cores/virtual/top_impl1.core
+++ b/tests/capi2_cores/virtual/top_impl1.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::top_impl1:0
+filesets:
+  rtl:
+    depend:
+      - ::user:0
+      - ::impl1:0
+    files:
+      - top_impl1.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: top_impl1

--- a/tests/capi2_cores/virtual/top_impl2.core
+++ b/tests/capi2_cores/virtual/top_impl2.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright FuseSoC contributors
+# Licensed under the 2-Clause BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: ::top_impl2:0
+filesets:
+  rtl:
+    depend:
+      - ::user:0
+      - ::impl2:0
+    files:
+      - top_impl2.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - rtl
+    toplevel: top_impl2

--- a/tests/test_coremanager.py
+++ b/tests/test_coremanager.py
@@ -243,17 +243,22 @@ def test_virtual():
     cm = CoreManager(Config())
     cm.add_library(Library("virtual", core_dir))
 
-    root_core = cm.get_core(Vlnv("::user"))
+    test_vectors = {
+        "::top_impl1": ["::impl1:0", "::user:0", "::top_impl1:0"],
+        "::top_impl2": ["::impl2:0", "::user:0", "::top_impl2:0"],
+    }
+    for top_vlnv, expected_deps in test_vectors.items():
+        root_core = cm.get_core(Vlnv(top_vlnv))
 
-    edalizer = Edalizer(
-        toplevel=root_core.name,
-        flags=flags,
-        core_manager=cm,
-        work_root=work_root,
-    )
-    edalizer.run()
+        edalizer = Edalizer(
+            toplevel=root_core.name,
+            flags=flags,
+            core_manager=cm,
+            work_root=work_root,
+        )
+        edalizer.run()
 
-    deps = cm.get_depends(root_core.name, {})
-    deps_names = [str(c) for c in deps]
+        deps = cm.get_depends(root_core.name, {})
+        deps_names = [str(c) for c in deps]
 
-    assert deps_names == ["::impl2:0", "::user:0"]
+        assert deps_names == expected_deps


### PR DESCRIPTION
Add "conflicts" constraints for each core implementing virtual VLNVs, so no two cores implementing the same virtual VLNV may be selected simultaneously.

This change should prevent more than a single implementing core from being selected as the implementation for a virtual VLNV, and when there is an explicit dependency in the tree, that one should be selected.