### PR TITLE
[setup] Bump fallback version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     use_scm_version={
         "relative_to": __file__,
         "write_to": "fusesoc/version.py",
-        "fallback_version": "0.4.dev0",
+        "fallback_version": "0.5.dev0",
     },
     author="Olof Kindgren",
     author_email="olof.kindgren@gmail.com",


### PR DESCRIPTION
When installing FuseSoC from OpenTitan -- that is, with

    pip install -r python-requirements.txt

Pip currently gets instructed to download

    https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.5.zip

However, that downloaded version **currently presents itself as version `0.4.dev0`**, to Pip as well as in `fusesoc --version`.  This is problematic in at least two ways:

1. Because Pip gets told that it downloaded version 0.4, it can prefer to use a locally cached archive (and I've seen it doing that!) that is *really* version 0.4, causing the update to become a NOP even though the user thinks they just updated FuseSoC.

2. Users have no way of distinguishing between versions 0.4 and 0.5 from the command line, which makes debugging difficult.

I don't know the root cause for why `use_scm_version` doesn't work as expected, but this hotfixes the fallback version to the currently tagged version.  We then need to update the Git tag to this commit and update the hash in the OpenTitan repo.