### PR TITLE
Bump simplesat to 0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "edalize>=0.2.3",
         "pyparsing",
         "pyyaml",
-        "simplesat>=0.8.0",
+        "simplesat>=0.9.1",
     ],
     # Supported Python versions: 3.6+
     python_requires=">=3.6, <4",


### PR DESCRIPTION
This is required for Python 3.11 and 3.12 support without syntax warnings / errors.

Passed the fusesoc test suite (after apply this patch due to change of branch name):

<details><summary>Test URL patch (expand)</summary>

```diff
diff --git a/tests/capi2_cores/providers/url_simple.core b/tests/capi2_cores/providers/url_simple.core
index df0f42e..35dcc4c 100644
--- a/tests/capi2_cores/providers/url_simple.core
+++ b/tests/capi2_cores/providers/url_simple.core
@@ -9,4 +9,4 @@ name : ::url_simple:0
 provider:
   name       : url
   filetype   : simple
-  url        : https://github.com/olofk/fusesoc/raw/master/tests/test_provider/file.v
+  url        : https://github.com/olofk/fusesoc/raw/main/tests/test_provider/file.v
diff --git a/tests/capi2_cores/providers/url_simple_with_user_agent.core b/tests/capi2_cores/providers/url_simple_with_user_agent.core
index 24d1b30..08b0008 100644
--- a/tests/capi2_cores/providers/url_simple_with_user_agent.core
+++ b/tests/capi2_cores/providers/url_simple_with_user_agent.core
@@ -9,5 +9,5 @@ name : ::url_simple_with_user_agent:0
 provider:
   name       : url
   filetype   : simple
-  url        : https://github.com/olofk/fusesoc/raw/master/tests/test_provider/file.v
+  url        : https://github.com/olofk/fusesoc/raw/main/tests/test_provider/file.v
   user-agent : FuseSoC
diff --git a/tests/capi2_cores/providers/url_tar.core b/tests/capi2_cores/providers/url_tar.core
index d9634a8..eace9a2 100644
--- a/tests/capi2_cores/providers/url_tar.core
+++ b/tests/capi2_cores/providers/url_tar.core
@@ -9,4 +9,4 @@ name : ::url_tar:0
 provider:
   name       : url
   filetype   : tar
-  url        : https://github.com/olofk/fusesoc/raw/master/tests/test_provider/file.tar.gz
+  url        : https://github.com/olofk/fusesoc/raw/main/tests/test_provider/file.tar.gz
diff --git a/tests/capi2_cores/providers/url_zip.core b/tests/capi2_cores/providers/url_zip.core
index 5d10cd5..0590bba 100644
--- a/tests/capi2_cores/providers/url_zip.core
+++ b/tests/capi2_cores/providers/url_zip.core
@@ -9,4 +9,4 @@ name : ::url_zip:0
 provider:
   name       : url
   filetype   : zip
-  url        : https://github.com/olofk/fusesoc/raw/master/tests/test_provider/file.zip
+  url        : https://github.com/olofk/fusesoc/raw/main/tests/test_provider/file.zip
```

</details>