### PR TITLE
Bump simplesat to 0.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     use_scm_version={
         "relative_to": __file__,
         "write_to": "fusesoc/version.py",
-        "fallback_version": "0.5.dev0",
+        "fallback_version": "0.6.dev0",
     },
     author="Olof Kindgren",
     author_email="olof.kindgren@gmail.com",
@@ -54,7 +54,7 @@ setup(
         "edalize>=0.2.3",
         "pyparsing",
         "pyyaml",
-        "simplesat>=0.8.0",
+        "simplesat>=0.9.1",
     ],
     # Supported Python versions: 3.6+
     python_requires=">=3.6, <4",


### PR DESCRIPTION
I merged against the wrong target in my last PR, my mistake. Let's try again.

The tests still pass except for one which is also failing on `ot-dev` without this change, so I think it's safe to ignore.

```
FAILED tests/test_coremanager.py::test_deptree - RuntimeError: Cannot find generated-child-a.sv in :
========================================= 1 failed, 48 passed, 2 warnings in 6.25s ==========================================
```